### PR TITLE
Update podfile from ios 9 to 10

### DIFF
--- a/react-native-redux-sample/ReactNativeWithSendBird/ios/Podfile
+++ b/react-native-redux-sample/ReactNativeWithSendBird/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '10.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'ReactNativeWithSendBird' do


### PR DESCRIPTION
Fixes the 
```
[!] CocoaPods could not find compatible versions for pod "RNCPushNotificationIOS":
  In Podfile:
    RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)

Specs satisfying the `RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)` dependency were found, but they required a higher minimum deployment target.
```
issue